### PR TITLE
Fixed: Off-by-one error skipping last character

### DIFF
--- a/MarkdownViewerPlusPlus/MarkdownViewer.cs
+++ b/MarkdownViewerPlusPlus/MarkdownViewer.cs
@@ -205,7 +205,7 @@ namespace com.insanitydesign.MarkdownViewerPlusPlus
         {
             try
             {
-                string editorText = this.Editor.GetText(this.Editor.GetLength());
+                string editorText = this.Editor.GetText(this.Editor.GetLength() + 1);
                 if (editorText != this.oldEditorText)
                 {
                     this.oldEditorText = editorText;


### PR DESCRIPTION
Quote from the official Scintilla documentation about [GetText](http://www.scintilla.org/ScintillaDoc.html#SCI_GETTEXT)

> This returns length-1 characters of text from the start of the document plus one terminating 0 character.