### PR TITLE
Fixed: Update renderer scrolling when caret causes a scroll event

### DIFF
--- a/MarkdownViewerPlusPlus/MarkdownViewer.cs
+++ b/MarkdownViewerPlusPlus/MarkdownViewer.cs
@@ -90,7 +90,7 @@ namespace com.insanitydesign.MarkdownViewerPlusPlus
                     UpdateMarkdownViewer();
 
                     //Update the scroll bar of the Viewer Panel only in case of vertical scrolls
-                    if (this.configuration.SynchronizeScrolling && notification.Updated == (uint)SciMsg.SC_UPDATE_V_SCROLL)
+                    if (this.configuration.SynchronizeScrolling && (notification.Updated & (uint)SciMsg.SC_UPDATE_V_SCROLL) != 0)
                     {
                         UpdateScrollBar();
                     }


### PR DESCRIPTION
If the caret was moved up or down far enough the editor would scroll, but the render window would not. This is due to the `Updated` field being a set of flags so only a single bit needs to be checked. [reference](http://www.scintilla.org/ScintillaDoc.html#SCN_UPDATEUI)