### PR TITLE
Fixed: Handle rendering markdown in either Editor views

### DIFF
--- a/MarkdownViewerPlusPlus/MarkdownViewer.cs
+++ b/MarkdownViewerPlusPlus/MarkdownViewer.cs
@@ -82,12 +82,6 @@ namespace com.insanitydesign.MarkdownViewerPlusPlus
         /// <param name="notification"></param>
         public void OnNotification(ScNotification notification)
         {
-            //Update the scintilla handle in all cases to keep track of which instance is active
-            if (notification.Header.Code == (uint)NppMsg.NPPN_BUFFERACTIVATED)
-            {
-                this.Editor.SetScintillaHandle(PluginBase.GetCurrentScintilla());
-            }
-
             //Listen to any UI update to get informed about all file changes, chars added/removed etc.
             if (this.renderer.Visible)
             {
@@ -99,6 +93,9 @@ namespace com.insanitydesign.MarkdownViewerPlusPlus
                 }
                 else if (notification.Header.Code == (uint)NppMsg.NPPN_BUFFERACTIVATED)
                 {
+                    //Update the scintilla handle in all cases to keep track of which instance is active
+                    this.Editor.SetScintillaHandle(PluginBase.GetCurrentScintilla());
+                    this.Editor.CurrentBufferID = notification.Header.IdFrom;
                     this.updateRenderer = true;
                     Update(true);
                 }

--- a/MarkdownViewerPlusPlus/MarkdownViewer.cs
+++ b/MarkdownViewerPlusPlus/MarkdownViewer.cs
@@ -82,42 +82,33 @@ namespace com.insanitydesign.MarkdownViewerPlusPlus
         /// <param name="notification"></param>
         public void OnNotification(ScNotification notification)
         {
+            //Update the scintilla handle in all cases to keep track of which instance is active
+            if (notification.Header.Code == (uint)NppMsg.NPPN_BUFFERACTIVATED)
+            {
+                this.Editor.SetScintillaHandle(PluginBase.GetCurrentScintilla());
+            }
+
             //Listen to any UI update to get informed about all file changes, chars added/removed etc.
             if (this.renderer.Visible)
-            {                
+            {
                 //Check for updates
                 if (notification.Header.Code == (uint)SciMsg.SCN_UPDATEUI)
                 {
-                    //Give the editor the message window handle
-                    IntPtr oldHandle = this.Editor.SetScintillaHandle(notification.Header.hwndFrom);
-                    //Update in case it changed
-                    this.updateRenderer = this.updateRenderer || oldHandle != notification.Header.hwndFrom;
                     //Update the view
                     Update((notification.Updated & (uint)SciMsg.SC_UPDATE_V_SCROLL) != 0);
                 }
-                else if (notification.Header.Code == (uint)NppMsg.NPPN_BUFFERACTIVATED
-                    && notification.Header.hwndFrom == PluginBase.nppData._nppHandle)
+                else if (notification.Header.Code == (uint)NppMsg.NPPN_BUFFERACTIVATED)
                 {
-                    //Update in case the main focus is lost (probably multi-window)
-                    this.Editor.SwitchScintillaHandle();
-                    Update();
+                    this.updateRenderer = true;
+                    Update(true);
                 }
-            }
-
-            //If the renderer is visible or not but shouldn't be updated -> Check that nothing "interesting" happened
-            if (!this.updateRenderer)
-            {
-                if (notification.Header.Code == (uint)SciMsg.SCN_MODIFIED)
+                else if (notification.Header.Code == (uint)SciMsg.SCN_MODIFIED && !this.updateRenderer)
                 {
                     bool isInsert = (notification.ModificationType & (uint)SciMsg.SC_MOD_INSERTTEXT) != 0;
                     bool isDelete = (notification.ModificationType & (uint)SciMsg.SC_MOD_DELETETEXT) != 0;
 
                     //Track if any text modifications have been made
-                    this.updateRenderer = this.updateRenderer || isInsert || isDelete;
-                }
-                else if (notification.Header.Code == (uint)NppMsg.NPPN_BUFFERACTIVATED)
-                {
-                    this.updateRenderer = true;
+                    this.updateRenderer = isInsert || isDelete;
                 }
             }
         }
@@ -211,6 +202,7 @@ namespace com.insanitydesign.MarkdownViewerPlusPlus
             //Show
             if (!this.renderer.Visible)
             {
+                this.updateRenderer = true;
                 UpdateMarkdownViewer();
                 UpdateScrollBar();
             }

--- a/MarkdownViewerPlusPlus/MarkdownViewer.cs
+++ b/MarkdownViewerPlusPlus/MarkdownViewer.cs
@@ -95,6 +95,12 @@ namespace com.insanitydesign.MarkdownViewerPlusPlus
                         UpdateScrollBar();
                     }
                 }
+                else if (notification.Header.Code == (uint)NppMsg.NPPN_BUFFERACTIVATED)
+                {
+                    //Update the Editor reference since the "other" one could be active now
+                    this.Editor = new ScintillaGateway(PluginBase.GetCurrentScintilla());
+                    this.updateRenderer = true;
+                }
             }
 
             //If the renderer is visible or not but shouldn't be updated -> Check that nothing "interesting" happened
@@ -107,10 +113,6 @@ namespace com.insanitydesign.MarkdownViewerPlusPlus
 
                     //Track if any text modifications have been made
                     this.updateRenderer = this.updateRenderer || isInsert || isDelete;
-                }
-                else if (notification.Header.Code == (uint)NppMsg.NPPN_BUFFERACTIVATED)
-                {
-                    this.updateRenderer = true;
                 }
             }
         }

--- a/MarkdownViewerPlusPlus/PluginInfrastructure/IScintillaGateway.cs
+++ b/MarkdownViewerPlusPlus/PluginInfrastructure/IScintillaGateway.cs
@@ -1,5 +1,6 @@
 ﻿// NPP plugin platform for .Net v0.93.87 by Kasper B. Graversen etc.
 
+using System;
 using static Kbg.NppPluginNET.PluginInfrastructure.Win32;
 
 namespace Kbg.NppPluginNET.PluginInfrastructure
@@ -13,6 +14,25 @@ namespace Kbg.NppPluginNET.PluginInfrastructure
     /// </summary>
     public interface IScintillaGateway
     {
+        /// <summary>
+        /// Change the Scintilla window handle for this Gateway
+        /// and return the previous handle for potentially final updates.
+        /// </summary>
+        /// <param name="newHandle"></param>
+        /// <returns></returns>
+        IntPtr SetScintillaHandle(IntPtr newHandle);
+
+        /// <summary>
+        /// Switch the handle between main and second window handle.
+        /// </summary>
+        void SwitchScintillaHandle();
+
+        /// <summary>
+        /// Return the current Scintilla window handle
+        /// </summary>
+        /// <returns></returns>
+        IntPtr GetScintillaHandle();
+
         int GetSelectionLength();
         void AppendTextAndMoveCursor(string text);
         void InsertTextAndMoveCursor(string text);

--- a/MarkdownViewerPlusPlus/PluginInfrastructure/IScintillaGateway.cs
+++ b/MarkdownViewerPlusPlus/PluginInfrastructure/IScintillaGateway.cs
@@ -33,6 +33,8 @@ namespace Kbg.NppPluginNET.PluginInfrastructure
         /// <returns></returns>
         IntPtr GetScintillaHandle();
 
+        uint CurrentBufferID { get; set; }
+
         int GetSelectionLength();
         void AppendTextAndMoveCursor(string text);
         void InsertTextAndMoveCursor(string text);

--- a/MarkdownViewerPlusPlus/PluginInfrastructure/ScintillaGateway.cs
+++ b/MarkdownViewerPlusPlus/PluginInfrastructure/ScintillaGateway.cs
@@ -20,6 +20,10 @@ namespace Kbg.NppPluginNET.PluginInfrastructure
 
         public static readonly int LengthZeroTerminator = "\0".Length;
 
+        /// <summary>
+        /// 
+        /// </summary>
+        public uint CurrentBufferID { get; set; }
 
         public ScintillaGateway(IntPtr scintilla)
         {

--- a/MarkdownViewerPlusPlus/PluginInfrastructure/ScintillaGateway.cs
+++ b/MarkdownViewerPlusPlus/PluginInfrastructure/ScintillaGateway.cs
@@ -16,7 +16,7 @@ namespace Kbg.NppPluginNET.PluginInfrastructure
     {
         private const int Unused = 0;
 
-        private readonly IntPtr scintilla;
+        private IntPtr scintilla;
 
         public static readonly int LengthZeroTerminator = "\0".Length;
 
@@ -24,6 +24,36 @@ namespace Kbg.NppPluginNET.PluginInfrastructure
         public ScintillaGateway(IntPtr scintilla)
         {
             this.scintilla = scintilla;
+        }
+
+        /// <summary>
+        /// Switch the handle between main and second window handle.
+        /// </summary>
+        public void SwitchScintillaHandle()
+        {
+            this.scintilla = this.scintilla == PluginBase.nppData._scintillaMainHandle ? PluginBase.nppData._scintillaSecondHandle : PluginBase.nppData._scintillaMainHandle;
+        }
+
+        /// <summary>
+        /// Change the Scintilla window handle for this Gateway
+        /// and return the previous handle for potentially final updates.
+        /// </summary>
+        /// <param name="newHandle"></param>
+        /// <returns></returns>
+        public IntPtr SetScintillaHandle(IntPtr newHandle)
+        {
+            IntPtr oldHandle = this.scintilla;
+            this.scintilla = newHandle;
+            return oldHandle;
+        }
+
+        /// <summary>
+        /// Return the current Scintilla window handle
+        /// </summary>
+        /// <returns></returns>
+        public IntPtr GetScintillaHandle()
+        {
+            return this.scintilla;
         }
 
         public int GetSelectionLength()

--- a/MarkdownViewerPlusPlus/Properties/AssemblyInfo.cs
+++ b/MarkdownViewerPlusPlus/Properties/AssemblyInfo.cs
@@ -32,5 +32,5 @@ using System.Runtime.InteropServices;
 // You can specify all the values or you can default the Build and Revision Numbers 
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("0.4.4.*")]
-[assembly: AssemblyFileVersion("0.4.4.0")]
+[assembly: AssemblyVersion("0.4.5.*")]
+[assembly: AssemblyFileVersion("0.4.5.0")]

--- a/README.md
+++ b/README.md
@@ -4,6 +4,7 @@ A Notepad++ Plugin to view a Markdown file rendered on-the-fly
 ## Features
 * Dockable panel (toggle) with a rendered HTML of the currently selected file/tab
 * CommonMark compliant ([0.27][4])
+* Synchronized scrolling
 * Links open in a separate Browser
 * Basic HTML Export
 * Basic PDF Export
@@ -18,13 +19,13 @@ A Notepad++ Plugin to view a Markdown file rendered on-the-fly
 * BugFixes ^^'
 
 ## Latest Versions
+* 0.4.5
+  * Fixed handling rendering Markdown in either editor view (thanks to dail8859)
 * 0.4.4
   * Update renderer scrolling when caret causes a scroll event (thanks to dail8859)
 * 0.4.3
   * Optimized viewer refresh calls in connection with Notepad++/Scintilla notifications (thanks to dail8859)
   * Changed the dependencies of [PDFSharp][5] and [HTMLRenderer][6] to pre-releases for better page-break support in PDF files
-* 0.4.2
-  * Fixed missing the last character from the editor text (thanks to dail8859)
   
 Download the latest [release here][9]. For a full version history go [here][10].
 


### PR DESCRIPTION
There was a bug when moving files to the "other view".

1. Open 2 or more files
2. Open MarkdownViewer
3. Move one of the files (Right click file name, Move to other view)
4. Edit the newly moved file
5. Nothing gets updated in the renderer

Two notes about these changes:

1. I moved the check for `NPPN_BUFFERACTIVATED` since it needs to be checked even when `this.updateRenderer == true`
2. I'm not that familiar with C# so I'm not sure if calling `new ScintillaGateway()` every time is a good way of handling this (it's the only way I know how currently). But the key idea here is that the current Scintilla instance could change when a new buffer is activated.