### PR TITLE
Revise installation steps for MarkdownViewerPlusPlus

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ A Notepad++ Plugin to view a Markdown file rendered on-the-fly
 Download the latest [release here][9]. For a full version history go [here][10].
 
 ## Installation
-Download a [release version][9] and copy the included **MarkdownViewerPlusPlus.dll** to the *plugins* sub-folder at your Notepad++ installation directory. The plugin adds a small Markdown icon ![Markdown icon](https://raw.githubusercontent.com/nea/MarkdownViewerPlusPlus/master/MarkdownViewerPlusPlus/Resources/markdown-16x16-solid.png) to the toolbar to toggle the viewer as dockable panel.
+Download a [release version][9], create a directory named **MarkdownViewerPlusPlus** in the *plugins* subfolder at your Notepad++ installation directory, and copy the included **MarkdownViewerPlusPlus.dll** to the *MarkdownViewerPlusPlus* directory. The plugin adds a small Markdown icon ![Markdown icon](https://raw.githubusercontent.com/nea/MarkdownViewerPlusPlus/master/MarkdownViewerPlusPlus/Resources/markdown-16x16-solid.png) to the toolbar to toggle the viewer as dockable panel.
 
 ### Plugin Manager
 If you have the [Plugin Manager][13] installed you can search for MarkdownViewer++ and install it via that plugin.


### PR DESCRIPTION
This pull request updates the installation instructions in the `README.md` to clarify the correct directory structure for installing the plugin. Instead of placing the `MarkdownViewerPlusPlus.dll` directly in the `plugins` folder, users are now instructed to create a `MarkdownViewerPlusPlus` subdirectory within `plugins` and place the DLL there. This helps ensure the plugin is recognized and loaded properly by Notepad++.

- Updated installation steps to require creating a `MarkdownViewerPlusPlus` directory inside the `plugins` folder and moving the DLL into it (`README.md`).